### PR TITLE
fix syntax error in the vagrantfile of apim-with-analytics and passwords contain "@"

### DIFF
--- a/APIM-ISasKM-with-Analytics/Vagrantfile
+++ b/APIM-ISasKM-with-Analytics/Vagrantfile
@@ -23,7 +23,7 @@ $stdout.print "login: "
 USERNAME = $stdin.gets.chomp
 $stdout.print "password: "
 PASSWORD = $stdin.noecho(&:gets).chomp
-TOKEN = [ERB::Util.url_encode(USERNAME), PASSWORD].join(':')
+TOKEN = [ERB::Util.url_encode(USERNAME), ERB::Util.url_encode(PASSWORD)].join(':')
 
 # load server configurations from YAML file
 CONFIGURATIONS = YAML.load_file('config.yaml')

--- a/APIM-with-Analytics/Vagrantfile
+++ b/APIM-with-Analytics/Vagrantfile
@@ -23,7 +23,7 @@ $stdout.print "login: "
 USERNAME = $stdin.gets.chomp
 $stdout.print "password: "
 PASSWORD = $stdin.noecho(&:gets).chomp
-TOKEN = [ERB::Util.url_encode(USERNAME), PASSWORD].join(':')
+TOKEN = [ERB::Util.url_encode(USERNAME), ERB::Util.url_encode(PASSWORD)].join(':')
 
 # load server configurations from YAML file
 CONFIGURATIONS = YAML.load_file('config.yaml')

--- a/APIM-with-Analytics/Vagrantfile
+++ b/APIM-with-Analytics/Vagrantfile
@@ -49,7 +49,7 @@ Vagrant.configure(2) do |config|
       #forwarding ports to access the server via localhost
       if server['ports']
         server['ports'].each do |port|
-          server_config.vm.network "forwarded_port", guest: port, host: port, guest_ip: box['ip']
+          server_config.vm.network "forwarded_port", guest: port, host: port, guest_ip: server['ip']
         end
       end
 


### PR DESCRIPTION
This fixes https://github.com/wso2/vagrant-apim/issues/25