### PR TITLE
Exposing spark UI port 4041

### DIFF
--- a/APIM-ISasKM-with-Analytics/config.yaml
+++ b/APIM-ISasKM-with-Analytics/config.yaml
@@ -28,6 +28,7 @@ servers:
     ip: 172.28.128.5
     ports:
       - 9444
+      - 4041
     ram: 2048
     cpu: 1
     provisioner_script: api-manager-analytics/provisioner/product_provisioner.sh

--- a/APIM-with-Analytics/config.yaml
+++ b/APIM-with-Analytics/config.yaml
@@ -28,6 +28,7 @@ servers:
     ip: 172.28.128.5
     ports:
       - 9444
+      - 4041
     ram: 2048
     cpu: 1
     provisioner_script: api-manager-analytics/provisioner/product_provisioner.sh


### PR DESCRIPTION
## Purpose
> Exposing Spark UI port 4041.

## Goals
> Allowing docker users to access Spark UI through the web browser
> Fixes #30 