### PR TITLE
Rename wso2is-as-km to wso2am-is-as-km

### DIFF
--- a/APIM-ISasKM-with-Analytics/config.yaml
+++ b/APIM-ISasKM-with-Analytics/config.yaml
@@ -35,8 +35,8 @@ servers:
     conf_dir: api-manager-analytics/confs
 
   -
-    hostname: wso2is-as-km
-    box: wso2is-as-km
+    hostname: wso2am-is-as-km
+    box: wso2am-is-as-km
     ip: 172.28.128.6
     ram: 2048
     cpu: 1

--- a/APIM-ISasKM-with-Analytics/is-as-km/provisioner/product_provisioner.sh
+++ b/APIM-ISasKM-with-Analytics/is-as-km/provisioner/product_provisioner.sh
@@ -23,7 +23,7 @@ WORKING_DIRECTORY=/home/vagrant
 JAVA_HOME=/opt/java/
 WUM_HOME=/usr/local
 WUM_PATH=PATH=$PATH:/usr/local/wum/bin
-CONFIGURATIONS=${WORKING_DIRECTORY}/api-manager-analytics/confs
+CONFIGURATIONS=${WORKING_DIRECTORY}/is-as-km/confs
 
 # operating in non-interactive mode
 export DEBIAN_FRONTEND=noninteractive


### PR DESCRIPTION
## Purpose
Rename the wso2is-as-km to wso2am-is-as-km, because the IS as Key Manager is only provided with WSO2 APIM.